### PR TITLE
feat: support native python types for operators

### DIFF
--- a/mgqpy/__init__.py
+++ b/mgqpy/__init__.py
@@ -1,6 +1,6 @@
 """mongo query as a predicate function"""
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 
 # Terminology
 #

--- a/mgqpy/operators/eq_ne_not.py
+++ b/mgqpy/operators/eq_ne_not.py
@@ -1,6 +1,8 @@
 import re
 from typing import List
 
+from mgqpy.utils import coerce
+
 import mgqpy
 
 
@@ -9,11 +11,13 @@ def _match_eq(doc, path: List[str], ov) -> bool:
         if isinstance(doc, list) and any([_match_eq(d, path, ov) for d in doc]):
             return True
 
+        # Regex special-case takes precedence
         if isinstance(ov, re.Pattern) and isinstance(doc, str):
-            if ov.search(doc):
-                return True
+            return bool(ov.search(doc))
 
-        return doc == ov
+        # Generic equality with type coercion
+        doc_coerced, ov_coerced = coerce(doc, ov)
+        return doc_coerced == ov_coerced
 
     key = path[0]
     rest = path[1:]

--- a/mgqpy/operators/gt.py
+++ b/mgqpy/operators/gt.py
@@ -3,11 +3,15 @@ from itertools import zip_longest
 from numbers import Number
 from typing import List
 
+from mgqpy.utils import coerce
+
 
 def _match_gt(doc, path: List[str], ov) -> bool:
     if len(path) == 0:
         if isinstance(doc, list) and any([_match_gt(d, path, ov) for d in doc]):
             return True
+
+        doc, ov = coerce(doc, ov)
 
         if isinstance(doc, list) and isinstance(ov, list):
             if doc > ov:
@@ -35,7 +39,11 @@ def _match_gt(doc, path: List[str], ov) -> bool:
         if isinstance(doc, str) and isinstance(ov, str):
             return operator.gt(doc, ov)
 
-        return False
+        # Fallback to rich comparison if possible (e.g. datetime)
+        try:
+            return operator.gt(doc, ov)
+        except Exception:
+            return False
 
     key = path[0]
     rest = path[1:]

--- a/mgqpy/operators/gte.py
+++ b/mgqpy/operators/gte.py
@@ -3,11 +3,15 @@ from itertools import zip_longest
 from numbers import Number
 from typing import List
 
+from mgqpy.utils import coerce
+
 
 def _match_gte(doc, path: List[str], ov) -> bool:
     if len(path) == 0:
         if isinstance(doc, list) and any([_match_gte(d, path, ov) for d in doc]):
             return True
+
+        doc, ov = coerce(doc, ov)
 
         if isinstance(doc, list) and isinstance(ov, list):
             if doc >= ov:
@@ -37,6 +41,11 @@ def _match_gte(doc, path: List[str], ov) -> bool:
 
         if isinstance(doc, str) and isinstance(ov, str):
             return operator.ge(doc, ov)
+
+        try:
+            return operator.ge(doc, ov)
+        except Exception:
+            pass
 
         if doc is None and ov is None:
             return True

--- a/mgqpy/operators/lt.py
+++ b/mgqpy/operators/lt.py
@@ -3,11 +3,15 @@ from itertools import zip_longest
 from numbers import Number
 from typing import List
 
+from mgqpy.utils import coerce
+
 
 def _match_lt(doc, path: List[str], ov) -> bool:
     if len(path) == 0:
         if isinstance(doc, list) and any([_match_lt(d, path, ov) for d in doc]):
             return True
+
+        doc, ov = coerce(doc, ov)
 
         if isinstance(doc, list) and isinstance(ov, list):
             if doc < ov:
@@ -37,6 +41,11 @@ def _match_lt(doc, path: List[str], ov) -> bool:
 
         if isinstance(doc, str) and isinstance(ov, str):
             return operator.lt(doc, ov)
+
+        try:
+            return operator.lt(doc, ov)
+        except Exception:
+            pass
 
         return False
 

--- a/mgqpy/operators/lte.py
+++ b/mgqpy/operators/lte.py
@@ -3,11 +3,15 @@ from itertools import zip_longest
 from numbers import Number
 from typing import List
 
+from mgqpy.utils import coerce
+
 
 def _match_lte(doc, path: List[str], ov) -> bool:
     if len(path) == 0:
         if isinstance(doc, list) and any([_match_lte(d, path, ov) for d in doc]):
             return True
+
+        doc, ov = coerce(doc, ov)
 
         if isinstance(doc, list) and isinstance(ov, list):
             if doc <= ov:
@@ -37,6 +41,11 @@ def _match_lte(doc, path: List[str], ov) -> bool:
 
         if isinstance(doc, str) and isinstance(ov, str):
             return operator.le(doc, ov)
+
+        try:
+            return doc <= ov
+        except Exception:
+            pass
 
         if doc is None and ov is None:
             return True

--- a/mgqpy/utils.py
+++ b/mgqpy/utils.py
@@ -1,0 +1,77 @@
+"""Utility helpers for mgqpy."""
+
+import datetime
+import decimal
+import uuid
+from typing import Any, Sequence
+
+
+def coerce(a: Any, b: Any) -> tuple[Any, Any]:
+    """Make *a* and *b* directly comparable by aligning their types.
+
+    The coercion rules are intentionally conservative – we only convert
+    where the *intent* is unambiguous (e.g. ISO-8601 date strings).  The
+    function never raises: if conversion fails we fall back to the
+    original values so the caller can attempt a normal comparison.
+    """
+
+    # Datetime ↔︎ ISO 8601 string
+    def _parse_date(s: str, target):
+        try:
+            if target is datetime.date:
+                return datetime.date.fromisoformat(s)
+            return datetime.datetime.fromisoformat(s)
+        except ValueError:
+            # Not a valid ISO format – leave as string so normal
+            # comparison semantics apply (and tests expecting a failure
+            # still pass).
+            return s
+
+    # If one side is date/datetime and the other a string → parse.
+    if isinstance(a, (datetime.date, datetime.datetime)) and isinstance(b, str):
+        b = _parse_date(b, type(a))
+        return a, b
+
+    if isinstance(b, (datetime.date, datetime.datetime)) and isinstance(a, str):
+        a = _parse_date(a, type(b))
+        return a, b
+
+    # Only attempt Decimal coercion when at least *one* operand is already a
+    # Decimal instance.
+    if isinstance(a, decimal.Decimal) or isinstance(b, decimal.Decimal):
+        a = a if isinstance(a, decimal.Decimal) else _try_decimal(a)[1]
+        b = b if isinstance(b, decimal.Decimal) else _try_decimal(b)[1]
+        return a, b
+
+    # UUID ↔︎ string
+    def _to_uuid(val: object):
+        if isinstance(val, uuid.UUID):
+            return val
+        if isinstance(val, str):
+            try:
+                return uuid.UUID(val)
+            except ValueError:
+                return val
+        return val
+
+    if isinstance(a, uuid.UUID) ^ isinstance(b, uuid.UUID):
+        return _to_uuid(a), _to_uuid(b)
+
+    # If no rule matched – leave untouched
+    return a, b
+
+
+# Decimal ↔︎ number / numeric-string
+def _try_decimal(val: object):
+    """Attempt to convert *val* to Decimal; returns (success, value)."""
+    if isinstance(val, decimal.Decimal):
+        return True, val
+    if isinstance(val, (int, float, str)) and not isinstance(val, bool):
+        try:
+            return True, decimal.Decimal(str(val))
+        except (decimal.InvalidOperation, ValueError):
+            pass
+    return False, val
+
+
+__all__: Sequence[str] = ("coerce",)

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -1,0 +1,100 @@
+"""Additional tests for python-native types that require coercion.
+
+These tests cover:
+* datetime.date ↔︎ ISO-8601 strings
+* decimal.Decimal ↔︎ numbers / numeric strings
+* uuid.UUID ↔︎ strings
+
+The document structures mimic the shape that would result from
+`pydantic.BaseModel.model_dump()` without importing pydantic here – the
+library should work with plain dict / list inputs provided by the user.
+"""
+
+import datetime as _dt
+import decimal as _dec
+import uuid as _uuid
+
+import pytest
+
+from mgqpy import Query
+
+
+@pytest.fixture()
+def fruit_basket_dict():
+    """Dictionary shaped like the output of a dumped Pydantic model."""
+
+    return {
+        "fruits": [
+            {"type": "berry", "harvested": _dt.date(2024, 8, 1)},
+            {"type": "aggregate", "harvested": _dt.date(2024, 8, 2)},
+    ]
+}
+
+
+@pytest.mark.parametrize(
+    "doc, query, expected",
+    [
+        (
+            {"ts": _dt.datetime(2025, 7, 31, 12, 0, 0)},
+            {"ts": {"$eq": "2025-07-31T12:00:00"}},
+            True,
+        ),
+        (
+            {"ts": _dt.datetime(2025, 7, 31, 12, 0, 0)},
+            {"ts": {"$gt": "2025-07-30T23:59:59"}},
+            True,
+        ),
+        (
+            {"ts": "2025-07-31T12:00:00"},
+            {"ts": {"$lt": _dt.datetime(2025, 8, 1)}},
+            True,
+        ),
+    ],
+)
+def test_datetime_coercion(doc, query, expected):
+    assert Query(query).test(doc) is expected
+
+
+
+def test_datetime_with_timezone():
+    aware = _dt.datetime(2025, 7, 31, 10, 0, 0, tzinfo=_dt.timezone.utc)
+
+    assert Query({"ts": {"$eq": "2025-07-31T10:00:00+00:00"}}).test({"ts": aware})
+    assert Query({"ts": {"$eq": aware}}).test({"ts": "2025-07-31T10:00:00+00:00"})
+
+
+@pytest.mark.parametrize(
+    "query, expected",
+    [
+        ({"fruits.0.harvested": {"$eq": "2024-08-01"}}, True),
+        ({"fruits.1.type": {"$eq": "aggregate"}}, True),
+        ({"fruits.harvested": {"$in": ["2024-08-02"]}}, True),
+        ({"fruits.0.harvested": {"$gt": "2024-07-31"}}, True),
+        ({"fruits.0.harvested": {"$lt": "2024-08-02"}}, True),
+    ],
+)
+def test_date_coercion(fruit_basket_dict, query, expected):
+    assert Query(query).test(fruit_basket_dict) is expected
+
+
+@pytest.mark.parametrize(
+    "doc, query, expected",
+    [
+        ({"x": _dec.Decimal("3.14")}, {"x": {"$eq": "3.14"}}, True),
+        ({"x": "2.71"}, {"x": {"$eq": _dec.Decimal("2.71")}}, True),
+        ({"x": _dec.Decimal("10")}, {"x": {"$gt": "9"}}, True),
+    ],
+)
+def test_decimal_coercion(doc, query, expected):
+    assert Query(query).test(doc) is expected
+
+
+@pytest.mark.parametrize(
+    "doc, query, expected",
+    [
+        ({"u": _uuid.UUID("0123456789abcdef0123456789abcdef")}, {"u": {"$eq": "0123456789abcdef0123456789abcdef"}}, True),
+        ({"u": "0123456789abcdef0123456789abcdef"}, {"u": {"$eq": _uuid.UUID("0123456789abcdef0123456789abcdef")}}, True),
+    ],
+)
+def test_uuid_coercion(doc, query, expected):
+    assert Query(query).test(doc) is expected


### PR DESCRIPTION
Hi @weiliddat, hope you're doing well. 

Question - would you be open to this extension? 

This makes it so that when there are native objects in the doc, that have a different JSON representation (datetime/date/decimal/uuid in this PR), and the filter value is parsable as native object, the filter value gets coerced before comparing. 

This allows serializing the filters as JSON (for persistence), and still having 'valid' results in query evaluation. Some work-arounds are possible, e.g. for `datetime`, the doc could be roundtripped to-from JSON, but for decimals for instance, this work-around doesn't work (because "9" > "10". 