### PR TITLE
feat: support timezones in type coercion

### DIFF
--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -86,6 +86,10 @@ def fruit_basket_dict():
             True,
         ),
         (
+            {"fruits.0.harvested": {"$eq": _dt.date(2024, 8, 1)}},
+            True,
+        ),
+        (
             {"fruits.1.type": {"$eq": "aggregate"}},
             True,
         ),
@@ -105,6 +109,12 @@ def fruit_basket_dict():
 )
 def test_date_coercion(fruit_basket_dict, query, expected):
     assert Query(query).test(fruit_basket_dict) is expected
+
+
+def test_date_filter_string_doc():
+    assert Query({"harvested": {"$eq": _dt.date(2024, 8, 1)}}).test(
+        {"harvested": "2024-08-01"}
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_python_types.py
+++ b/tests/test_python_types.py
@@ -28,6 +28,16 @@ from mgqpy import Query
             True,
         ),
         (
+            {"ts": _dt.datetime(2025, 7, 31, 0, 0, 0)},
+            {"ts": {"$eq": "2025-07-31"}},
+            True,
+        ),
+        (
+            {"ts": _dt.datetime(2025, 7, 31, 12, 0, 0)},
+            {"ts": {"$gt": "2025-07-31"}},
+            True,
+        ),
+        (
             {"ts": _dt.datetime(2025, 7, 31, 12, 0, 0)},
             {"ts": {"$gt": "2025-07-30T23:59:59"}},
             True,
@@ -53,6 +63,7 @@ def test_datetime_with_timezone():
 
     assert Query({"ts": {"$eq": "2025-07-31T10:00:00+00:00"}}).test({"ts": aware})
     assert Query({"ts": {"$eq": aware}}).test({"ts": "2025-07-31T10:00:00+00:00"})
+    assert Query({"ts": {"$gt": "2025-07-31"}}).test({"ts": aware})
 
 
 @pytest.fixture()


### PR DESCRIPTION
Current type coercion logic does not consider if LHS/RHS are timezone-aware or not. This PR would make mgqpy adapt the timezone of the 'coerced' value to the timezone of the compare-target. 